### PR TITLE
Allow Vue "extends" option to work

### DIFF
--- a/vue-super.js
+++ b/vue-super.js
@@ -47,7 +47,10 @@ function $super(type, self) {
     if (!(self instanceof type))
         throw new TypeError(`<${vueName(self.constructor)}> not an instance of <${vueName(type)}>`);
 
-    const unbound = type.super.options.methods || {};
+    const unbound = {
+        ...(type.options.extends && type.options.extends.methods || {}),
+        ...(type.super.options.methods || {})
+    };
     const bound = {};
 
     for (const key of Object.keys(unbound))


### PR DESCRIPTION
Currently, it's not possible to invoke super methods when the component is extended using the [extends](https://vuejs.org/v2/api/#extends) option.